### PR TITLE
Fix MSVC C4668 on _HAS_NAMESPACE

### DIFF
--- a/include/boost/config/stdlib/dinkumware.hpp
+++ b/include/boost/config/stdlib/dinkumware.hpp
@@ -96,7 +96,7 @@
 #include <exception>
 #endif
 #include <typeinfo>
-#if ( (!_HAS_EXCEPTIONS && !defined(__ghs__)) || (!_HAS_NAMESPACE && defined(__ghs__)) ) && !defined(__TI_COMPILER_VERSION__) && !defined(__VISUALDSPVERSION__) \
+#if ( (!_HAS_EXCEPTIONS && !defined(__ghs__)) || (defined(__ghs__) && !_HAS_NAMESPACE) ) && !defined(__TI_COMPILER_VERSION__) && !defined(__VISUALDSPVERSION__) \
 	&& !defined(__VXWORKS__)
 #  define BOOST_NO_STD_TYPEINFO
 #endif  


### PR DESCRIPTION
This PR resolves an instance of MSVC warning C4668 (undefined preprocessor macro) for _HAS_NAMESPACE, by short-circuiting (checking for Green Hills compiler first).